### PR TITLE
Add ability to convert attributes from OpenAPI definitions other than components.schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,11 @@
         "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
         "commander": "^11.0.0",
         "desm": "^1.3.0",
+        "filenamify": "^6.0.0",
         "fs-extra": "^11.1.1",
         "json-schema-to-typescript": "^13.0.1",
+        "lodash.get": "^4.4.2",
+        "lodash.trimstart": "^4.5.1",
         "pino": "^8.14.1",
         "yaml": "^2.2.2"
       },
@@ -2637,6 +2640,31 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -4035,6 +4063,11 @@
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -4095,6 +4128,11 @@
       "dependencies": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "node_modules/lodash.trimstart": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimstart/-/lodash.trimstart-4.5.1.tgz",
+      "integrity": "sha512-b/+D6La8tU76L/61/aN0jULWHkT0EeJCmVstPBn/K9MtD2qBW83AsBNrr63dKuWYwVMO7ucv13QNO/Ek/2RKaQ=="
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -10521,6 +10559,19 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw=="
+    },
+    "filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "requires": {
+        "filename-reserved-regex": "^3.0.0"
+      }
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -11536,6 +11587,11 @@
       "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
+    },
     "lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -11596,6 +11652,11 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.trimstart": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimstart/-/lodash.trimstart-4.5.1.tgz",
+      "integrity": "sha512-b/+D6La8tU76L/61/aN0jULWHkT0EeJCmVstPBn/K9MtD2qBW83AsBNrr63dKuWYwVMO7ucv13QNO/Ek/2RKaQ=="
     },
     "lodash.uniq": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,11 @@
     "@openapi-contrib/openapi-schema-to-json-schema": "^5.1.0",
     "commander": "^11.0.0",
     "desm": "^1.3.0",
+    "filenamify": "^6.0.0",
     "fs-extra": "^11.1.1",
     "json-schema-to-typescript": "^13.0.1",
+    "lodash.get": "^4.4.2",
+    "lodash.trimstart": "^4.5.1",
     "pino": "^8.14.1",
     "yaml": "^2.2.2"
   },

--- a/src/commands/oas2json.js
+++ b/src/commands/oas2json.js
@@ -23,18 +23,12 @@ export const adaptSchema = (generatedSchema, name, filename) => {
   }
 }
 
-const processSchema = (
-  name,
-  schema,
-  schemasPath,
-  logger = pino(),
-  dirname = ''
-) => {
+const processSchema = (name, schema, schemasPath, logger, dirname = '') => {
   let generatedSchema
   try {
     generatedSchema = fromSchema(schema)
   } catch (error) {
-    logger.warn(`Failed to generate schema for property ${dirname}, skipping`)
+    logger.warn('Failed to convert non-object attribute, skipping')
     return
   }
 
@@ -147,7 +141,7 @@ oas2json
   )
   .option(
     '-p, --properties <string>',
-    'Comma-separated list of properties to export from the OpenAPI file'
+    'Comma-separated list of properties to convert from the OpenAPI file'
   )
   .allowUnknownOption()
   .allowExcessArguments(true)


### PR DESCRIPTION
Resolves #54 

**Manual testing carried out:**
* [x] Can still convert `components.schemas`
* [x] Can convert attributes who have their own properties, accessible with the `-p` or `--properties` argument using dot notation
* [x] If one or more of the aforementioned attributes contains a `$ref` field, `components.schemas` is converted automatically
* [x] When converting list-type attributes, the name of the attribute is used for the filename and not the index
* [x] A warning is logged when attempting to convert an attribute with no properties, and this doesn't cause the process to exit