### PR TITLE
feat: added flag to exclude  of dereferenced schemas

### DIFF
--- a/test/oas2tson.test.js
+++ b/test/oas2tson.test.js
@@ -133,4 +133,126 @@ tap.test('oas2tson', async t => {
       'Customer.ts is created correctly'
     )
   })
+
+  t.test('runCommand function with excludeDereferencedIds', async t => {
+    fs.ensureDirSync(TEST_DIRECTORY)
+
+    await runCommand(inputPath, outputPath, null, true)
+
+    const generatedFiles = fs.readdirSync(outputPath)
+
+    t.match(
+      generatedFiles,
+      [
+        'Address.ts',
+        'ApiResponse.ts',
+        'Category.ts',
+        'Customer.ts',
+        'Order.ts',
+        'Pet.ts',
+        'Tag.ts',
+        'User.ts'
+      ],
+      'generates the expected TS files'
+    )
+
+    const PetFile = resolveFromPackageRoot(outputPath, 'Pet.ts')
+    const generatedPetFile = fs.readFileSync(PetFile, 'utf-8')
+
+    t.same(
+      generatedPetFile,
+      `export const Pet = {
+  required: ["name", "photoUrls"],
+  type: "object",
+  properties: {
+    id: {
+      type: "integer",
+      format: "int64",
+      minimum: -9223372036854776000,
+      maximum: 9223372036854776000,
+    },
+    name: { type: "string" },
+    category: {
+      type: "object",
+      properties: {
+        id: {
+          type: "integer",
+          format: "int64",
+          minimum: -9223372036854776000,
+          maximum: 9223372036854776000,
+        },
+        name: { type: "string" },
+      },
+      title: "Category",
+    },
+    photoUrls: { type: "array", items: { type: "string" } },
+    tags: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          id: {
+            type: "integer",
+            format: "int64",
+            minimum: -9223372036854776000,
+            maximum: 9223372036854776000,
+          },
+          name: { type: "string" },
+        },
+        title: "Tag",
+      },
+    },
+    status: {
+      type: "string",
+      description: "pet status in the store",
+      enum: ["available", "pending", "sold"],
+    },
+    nullableValue: {
+      type: ["string", "null"],
+      description: "example nullable value",
+    },
+  },
+  title: "Pet",
+  $id: "Pet.json",
+} as const;
+`,
+      'Pet.ts is created correctly'
+    )
+
+    const CustomerFile = resolveFromPackageRoot(outputPath, 'Customer.ts')
+    const generatedCustomerFile = fs.readFileSync(CustomerFile, 'utf-8')
+
+    t.same(
+      generatedCustomerFile,
+      `export const Customer = {
+  type: "object",
+  properties: {
+    id: {
+      type: "integer",
+      format: "int64",
+      minimum: -9223372036854776000,
+      maximum: 9223372036854776000,
+    },
+    username: { type: "string" },
+    address: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          street: { type: "string" },
+          city: { type: "string" },
+          state: { type: "string" },
+          zip: { type: "string" },
+        },
+        title: "Address",
+      },
+    },
+  },
+  title: "Customer",
+  $id: "Customer.json",
+} as const;
+`,
+      'Customer.ts is created correctly'
+    )
+  })
 })


### PR DESCRIPTION
Added the `excludeDereferencedIds` to allow removal of `$id` in dereferenced schemas. 

closes (#179)