### PR TITLE
fix: oas2ts imports ignore config

### DIFF
--- a/example/output/types/Customer.d.ts
+++ b/example/output/types/Customer.d.ts
@@ -1,4 +1,4 @@
-import { Address } from './Address'
+import { Address } from './Address';
 
 /* eslint-disable */
 /**

--- a/example/output/types/Pet.d.ts
+++ b/example/output/types/Pet.d.ts
@@ -1,5 +1,5 @@
-import { Category } from './Category'
-import { Tag } from './Tag'
+import { Category } from './Category';
+import { Tag } from './Tag';
 
 /* eslint-disable */
 /**

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "lodash.trimstart": "^4.5.1",
     "lodash.upperfirst": "^4.3.1",
     "pino": "^9.0.0",
+    "prettier": "^3.0.1",
     "yaml": "^2.2.2"
   },
   "devDependencies": {
@@ -69,7 +70,6 @@
     "husky": "^9.0.11",
     "lint-staged": "^15.0.2",
     "markdown-toc": "^1.2.0",
-    "prettier": "^3.0.1",
     "tap": "^20.0.0",
     "tsup": "^8.0.2",
     "typescript": "^5.4.5"

--- a/src/commands/json2ts.ts
+++ b/src/commands/json2ts.ts
@@ -41,7 +41,10 @@ const generateAndWriteTsFile = async (
     .join('\n')
 
   const tsWithImports = `${imports ? `${imports}\n\n` : ''}${ts}`
-  const tsFormatted = await format(tsWithImports, {parser: 'typescript', ...options.style})
+  const tsFormatted = await format(tsWithImports, {
+    parser: 'typescript',
+    ...options.style
+  })
 
   const tsFileName = path.basename(schemaPath, '.json') + '.d.ts'
 

--- a/src/commands/json2ts.ts
+++ b/src/commands/json2ts.ts
@@ -12,6 +12,7 @@ import type {
 } from '../types/Json2TsOptions'
 import { doNotEditText } from '../utils/do-not-edit-text.js'
 import { readConfigFile } from '../utils/read-config-file.js'
+import { format } from 'prettier'
 
 const generateAndWriteTsFile = async (
   schemaPath: string,
@@ -40,9 +41,11 @@ const generateAndWriteTsFile = async (
     .join('\n')
 
   const tsWithImports = `${imports ? `${imports}\n\n` : ''}${ts}`
+  const tsFormatted = await format(tsWithImports, {parser: 'typescript', ...options.style})
+
   const tsFileName = path.basename(schemaPath, '.json') + '.d.ts'
 
-  fs.writeFileSync(path.join(tsTypesPath, tsFileName), tsWithImports)
+  fs.writeFileSync(path.join(tsTypesPath, tsFileName), tsFormatted)
 }
 
 export const runCommand = async (

--- a/test/json2ts.test.ts
+++ b/test/json2ts.test.ts
@@ -39,8 +39,8 @@ tap.test('json2ts runCommand', async t => {
 
   t.same(
     generatedPetFile,
-    `import { Category } from './Category'
-import { Tag } from './Tag'
+    `import { Category } from "./Category";
+import { Tag } from "./Tag";
 
 /* eslint-disable */
 /**
@@ -70,7 +70,7 @@ export interface Pet {
 
   t.same(
     generatedCustomerFile,
-    `import { Address } from './Address'
+    `import { Address } from "./Address";
 
 /* eslint-disable */
 /**

--- a/test/oas2ts.test.ts
+++ b/test/oas2ts.test.ts
@@ -35,8 +35,8 @@ tap.test('oas2ts', async t => {
 
     t.same(
       generatedPetFile,
-      `import { Category } from './Category'
-import { Tag } from './Tag'
+      `import { Category } from "./Category";
+import { Tag } from "./Tag";
 
 /* eslint-disable */
 /**
@@ -70,7 +70,7 @@ export interface Pet {
 
     t.same(
       generatedCustomerFile,
-      `import { Address } from './Address'
+      `import { Address } from "./Address";
 
 /* eslint-disable */
 /**


### PR DESCRIPTION
Import statements are parsed and added to the generated typescript after `json-schema-to-typescript` runs. This change runs `prettier` with the provided config on the generated code after the imports have been added.


Fixes #273 