### PR TITLE
chore(deps): group minor + patch dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,19 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Bundle backwards-compatible (minor + patch) bumps into ONE PR.
+    # Majors are excluded, so they keep coming as separate reviewable PRs.
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Adds a `groups` block to `.github/dependabot.yml` (npm + github-actions) that bundles **minor + patch** updates into a single PR per ecosystem, while **majors stay as separate individual PRs**.

Going forward dependabot opens one grouped PR instead of a dozen, so the backlog doesn't rebuild. Config-only change — no application code touched.

Companion to the verified minor/patch bump PR (#618), which clears the current backlog. **For human review + merge — not merging anything myself.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)